### PR TITLE
Don't write tabs into sequence names in index file

### DIFF
--- a/Fasta.cpp
+++ b/Fasta.cpp
@@ -34,7 +34,7 @@ void FastaIndexEntry::clear(void)
 
 ostream& operator<<(ostream& output, const FastaIndexEntry& e) {
     // just write the first component of the name, for compliance with other tools
-    output << split(e.name, ' ').at(0) << "\t" << e.length << "\t" << e.offset << "\t" <<
+    output << split(e.name, ' \t').at(0) << "\t" << e.length << "\t" << e.offset << "\t" <<
         e.line_blen << "\t" << e.line_len;
     return output;  // for multiple << operators.
 }

--- a/Fasta.cpp
+++ b/Fasta.cpp
@@ -34,7 +34,7 @@ void FastaIndexEntry::clear(void)
 
 ostream& operator<<(ostream& output, const FastaIndexEntry& e) {
     // just write the first component of the name, for compliance with other tools
-    output << split(e.name, ' \t').at(0) << "\t" << e.length << "\t" << e.offset << "\t" <<
+    output << split(e.name, " \t").at(0) << "\t" << e.length << "\t" << e.offset << "\t" <<
         e.line_blen << "\t" << e.line_len;
     return output;  // for multiple << operators.
 }


### PR DESCRIPTION
Previously, if the `>` line of the FASTA file included a tab, it would be written into the sequence name in the serialized index, which would then cause the FAI to be rejected for having the wrong number of columns.